### PR TITLE
Show install button only on home and improve spec row styling

### DIFF
--- a/src/layouts/TheLayout.vue
+++ b/src/layouts/TheLayout.vue
@@ -11,13 +11,15 @@ const component = computed(() => {
   if (route.meta && route.meta.layout === false) return undefined
   else return DefaultLayout
 })
+
+const isHomePage = computed(() => route.path === '/')
 </script>
 
 <template>
   <teleport to="head">
     <link rel="manifest" href="/manifest.json">
   </teleport>
-  <button id="install-button" style="display: none;
+  <button id="install-button" v-if="isHomePage" style="display: none;
            position: fixed;
            bottom: 1rem;
            right: 1rem;

--- a/src/views/product/components/SpecSection.vue
+++ b/src/views/product/components/SpecSection.vue
@@ -8,7 +8,11 @@
     </div>
     <table class="w-100 table-striped">
       <tbody>
-        <tr v-for="(value, key, index) in props.spec" :key="index" :class="index % 2 === 0 ? 'spec-even-bg' : ''">
+        <tr
+          v-for="(value, key, index) in props.spec"
+          :key="index"
+          :class="index % 2 === 0 ? 'spec-even-bg' : 'spec-odd-bg'"
+        >
           <td class="px-2 py-2">{{ key }}:</td>
           <td class="px-2 py-2">{{ value }}</td>
         </tr>
@@ -27,6 +31,9 @@ const props = defineProps<{
 <style lang="scss" scoped>
 .spec-even-bg {
   background-color: var(--v-theme-surface-variant, var(--v-theme-surface));
+}
+.spec-odd-bg {
+  background-color: var(--v-theme-surface);
 }
 
 


### PR DESCRIPTION
The install button in TheLayout.vue is now only visible on the home page by using a computed property. In SpecSection.vue, odd and even table rows are given distinct background classes for clearer visual separation.